### PR TITLE
feat(multi-folder-workspace): support them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the "scuri-code" extension will be documented in this file.
 
 ## Versions
+## [1.4.0] - 2021-07-29
+
+### Fixed
+-   support multi-folder workspace
+
+
 ## [1.3.1] - 2021-06-14
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,7 +13,7 @@ Scuri code is a VS Code [extension](https://marketplace.visualstudio.com/items?i
 - start a discussion in the [issues](https://github.com/gparlakov/scuri-code/issues)
 - fork the project [fork](https://github.com/gparlakov/scuri-code)
 - work in a branch `feature/my-awesome-feature-request`
-- open a PR and please add some tests for what you've experienced
+- open a PR and please add some tests for what you've experienced/corrected/added
 
 ## Testing
 Tests are using [mocha](https://mochajs.org/) and live inside `src/test` folder e.g. [src/test/path-with-spaces.test.ts](src/test/suite/path-with-spaces.test.ts)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,13 +78,15 @@ function scuriCommand(
         const a = window.activeTextEditor;
         // tslint:disable-next-line:triple-equals
         if (a != null && workspace.getWorkspaceFolder(a.document.uri) != null) {
-          const root = workspace.getWorkspaceFolder(a.document.uri);
+          const root = workspace.getWorkspaceFolder(a.document.uri)!;
+
           options = options || '';
           // need to add --debug false as the schematics engine assumes debug true when specifying the schematic by folder vs package name
           options += ' --debug false';
+
           return command(
-            workspace.asRelativePath(a.document.fileName),
-            root!.uri.fsPath,
+            workspace.asRelativePath(a.document.uri, false),
+            root.uri.fsPath,
             channel,
             options,
             schematic
@@ -233,9 +235,7 @@ function installDeps(channel: OutputChannel, context?: ExtensionContext) {
                 context.globalState.update(key_installing, true);
               }
 
-              channel.appendLine(
-                'Start installing deps. Could take a couple of minutes'
-              );
+              channel.appendLine('Start installing deps. Could take a couple of minutes');
               channel.appendLine(`npm install scuri@latest @angular-devkit/schematics-cli@latest`);
 
               const proc = c.exec(

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -6,7 +6,7 @@ export function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
 		ui: 'tdd',
-		timeout: 10000
+		timeout: 60000 // downloading the new versions interminttently takes a lot of time
 	});
 	mocha.useColors(true);
 

--- a/src/test/suite/show-errors-and-result.test.ts
+++ b/src/test/suite/show-errors-and-result.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { suiteSetup, test } from 'mocha';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import { Uri, workspace, commands, window  } from 'vscode';
+import { workspace, commands, window  } from 'vscode';
 import { cleanUpFiles } from './util/clean-up-files';
 const { executeCommand } = commands;
 


### PR DESCRIPTION
- add support for multi-folder workspaces by 
skipping the workspace folder when
passing the name of the file to update
- the root already contains the workspace folder of the file so
no need to duplicate that